### PR TITLE
added support for cygwin under windows

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -96,7 +96,7 @@ exports.create = function (callback, options) {
             var runPidFinder = function () {
                 switch (platform) {
                     case 'linux':
-                        cmd = 'netstat -nlp | grep ' + pid + '/';
+                        cmd = 'PPID=`ps -f --ppid ' + pid + ' | grep ' + pid + ' | awk \' { print $2 } \'` ; netstat -nlp | grep ${PPID}/';
                         break;
                     case 'darwin':
                         cmd = 'lsof -p ' + pid + ' | grep LISTEN';


### PR DESCRIPTION
As the topic explains, I have added support to find the phantom pid when running cygwin under windows.

For some reason git thinks the whole file has been changed, but infact it's only line 94-121 that has been slightly modified.
