### PR TITLE
Fixed detection of correct process and added Cygwin support

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -93,13 +93,13 @@ exports.create = function (callback, options) {
             var cmd = null;
             switch (platform) {
                 case 'linux':
-                            cmd = 'netstat -nlp | grep ' + pid + '/';
+                            cmd = 'netstat -nlp | grep "[[:space:]]' + pid + '/"';
                             break;
                 case 'darwin':
                             cmd = 'lsof -p ' + pid + ' | grep LISTEN';
                             break;
                 case 'win32':
-                            cmd = 'netstat -ano | find "' + pid + '"';
+                            cmd = 'netstat -ano | findstr /R "\\<' + pid + '$"';
                             break;
                 default:
                             phantom.kill();


### PR DESCRIPTION
With using grep (in Linux) or find (in Windows) without boundaries it could happen that the wrong process was found (for example if the PID was part of an open port of another application). By using boundaries (space before and line-end/slash after the PID) this mismatch can no longer happen. I know this was unlikely under Linux but I also fixed it there.

By coincidence using findstr instead of find in Windows also added automatic cygwin support because there is no longer a collision for the find command.

This simplifies the solution for #8 and is related to #9.
