### PR TITLE
Have the bridge report the pid of child phantomjs

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -186,4 +186,4 @@ var global_methods = {
 	},
 }
 
-console.log("Ready " + system.pid);
+console.log("Ready pid=" + system.pid);

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -115,11 +115,12 @@ exports.create = function (callback, options) {
             phantom.stdout.on('data', function (data) {
                 return console.log('phantom stdout: '+data);
             });
-            if (!/Ready.*/.test(data)) {
+            var matches = data.toString().match(/Ready pid=(\d+)/);
+            if (!matches) {
                 phantom.kill();
                 return callback("Unexpected output from PhantomJS: " + data);
             }
-            var phantom_pid = data.toString().replace('Ready ', '');
+            var phantom_pid = parseInt(matches[1], 0);
 
             // Now need to figure out what port it's listening on - since
             // Phantom is busted and can't tell us this we need to use lsof on mac, and netstat on Linux

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Matt Sergeant (matt@hubdoc.com)",
   "name": "node-phantom-simple",
   "description": "Simple and reliable bridge between Node.js and PhantomJS",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/baudehlo/node-phantom-simple",
   "repository": {
     "type": "git",


### PR DESCRIPTION
My computer (Ubuntu 12.04.4 LTS) was reporting phantom.pid as a forked child nodejs process, which itself had a child phantomjs process. Consequently, the pids did not match in netstat's output. I modified bridge.js to report the pid of the phantomjs process, so that it could be picked up and found in netstat's output.
