### PR TITLE
Fix possible ECONNRESET

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -449,7 +449,7 @@ function setup_long_poll (phantom, port, pages, setup_new_page) {
             });
         });
         req.on('error', function (err) {
-            if (dead) return;
+            if (dead || phantom.killed) return;
             console.warn("Poll Request error: " + err);
         });
     };


### PR DESCRIPTION
Hi,
I am randomly (~2% of the time) getting a `Poll Request error: Error: read ECONNRESET`.

To my understanding, the issue could be that the poll function request fails when `phantom.kill` is executed, and its error callback could be fired before `phantom.once('exit'...`, resulting in the "dead" variable still being false.

This fix solves the problem on my end!
