### PR TITLE
Fix win32 cmd for retrieving phantom port

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -139,7 +139,7 @@ exports.create = function (callback, options) {
                             cmd = 'lsof -p %d | grep LISTEN';
                             break;
                 case 'win32':
-                            cmd = 'netstat -ano | findstr /R "\\<%d$"';
+                            cmd = 'netstat -ano | findstr /R "\\<%d\\>"';
                             break;
                 case 'cygwin':
                             cmd = 'netstat -ano | grep %d';


### PR DESCRIPTION
The original cmd didn't return any results (there is a white character after the port).
