### PR TITLE
Error to be thrown, fail-fast & loudly rather than console.log

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -97,7 +97,7 @@ exports.create = function (callback, options) {
             if (options.ignoreErrorPattern && options.ignoreErrorPattern.exec(data)) {
                 return;
             }
-            return console.warn('phantom stderr: '+data);
+            throw new Error(data);
         });
         var exitCode = 0;
         phantom.once('exit', function (code) {


### PR DESCRIPTION
Error from phantom should be able to delivered to caller and let it decide what to do with error, for instance, restart phantom instance.