### PR TITLE
Yosemite support for multiple local hostnames

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -136,7 +136,7 @@ exports.create = function (callback, options) {
                             cmd = 'netstat -nlp | grep "[[:space:]]%d/"';
                             break;
                 case 'darwin':
-                            cmd = 'lsof -p %d | grep LISTEN';
+                            cmd = 'lsof -np %d | grep LISTEN';
                             break;
                 case 'win32':
                             cmd = 'netstat -ano | findstr /R "\\<%d\\>"';


### PR DESCRIPTION
It looks like the lsof command in darwin will now return the last entry in /etc/hosts as the hostname for any application running on localhost, so for users with MAMP Pro which automatically managed /etc/hosts, this will be the bottom most website setup in MAMP Pro.

In my case, it fails with:

Fatal error: Error extracting port from: phantomjs 89461 Liam 12u IPv4 0xdd3c25009a2ebb05 0t0 TCP gladdy.local:60628 (LISTEN)

This change stops lsof returning any hostnames, so the 127.0.0.1 part of the hostname will match (Should the hostname/IP regex be updated to support ::1 too?)