### PR TITLE
Fixed issue causing waitForSelector() to always timeout.

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -251,7 +251,7 @@ exports.create = function (callback, options) {
 
                         page.evaluate(function (selector) {
                             return document.querySelectorAll(selector).length;
-                        }, function (result) {
+                        }, function (err, result) {
                             testRunning = false;
                             if (result > 0) {//selector found
                                 cb();


### PR DESCRIPTION
page.waitForSelector() was never returning because the cb parameter function to page.evaluate() expects two parameters (err and result), and only one was defined.
