### PR TITLE
If the phantom process dies, tell people

### DIFF
--- a/tests/testUnexpectedExit.js
+++ b/tests/testUnexpectedExit.js
@@ -1,0 +1,14 @@
+var phantom=require('../node-phantom-simple');
+
+exports.testUnexpectedExit = function(test) {
+    phantom.create(function (error, ph) {
+        test.ifError(error);
+        ph.createPage(function (err,page) {
+            ph.exit();  // exit the phantom process at a strange time
+            page.open('http://www.google.com', function(err, result) {
+              test.ok(!!err); // we expect an error
+              test.done();
+            })
+        });
+    });
+};


### PR DESCRIPTION
There are several cases where the phantom process can die and any pending callbacks will never be notified.  This is an unfortunate situation.
- In the poll_func, instead of simply returning in these cases, we call the callback with an error param.
- In the request_queue, if the requests emits an error, we call the callback with the error and do not call the next item in the queue as any operations after this point will be in an undefined state.
- In the callbackOrDummy function, we add a little error handling to the poll_func callback.  If the poll_func callback gets an error we pass that error on.  In this way, you must pass both poll_func and the original arguments…  In case we have a strange race

Finally, I added a simple test.
