### PR TITLE
Add webserver port parameter (netstat/lsof not available on restricted unix platforms like Heroku) until PhantomJS webserver port issue is fixed.

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -5,7 +5,7 @@ var args        = system.args;
 
 var pages  = {};
 var page_id = 1;
-var webserverPort = args[1];
+var webserver_port = args[1] || 0;
 
 var callback_stack = [];
 
@@ -51,7 +51,7 @@ function include_js (res, page, args) {
 	}));
 }
 
-var service = webserver.listen('127.0.0.1:' + (webserverPort || 0), function (req, res) {
+var service = webserver.listen('127.0.0.1:' + webserver_port, function (req, res) {
 	// console.log("Got a request of type: " + req.method);
 	if (req.method === 'GET') {
 		res.statusCode = 200;

--- a/bridge.js
+++ b/bridge.js
@@ -1,9 +1,11 @@
 var webpage     = require('webpage');
 var webserver   = require('webserver').create();
 var system      = require('system');
+var args        = system.args;
 
 var pages  = {};
 var page_id = 1;
+var webserverPort = args[1];
 
 var callback_stack = [];
 
@@ -49,7 +51,7 @@ function include_js (res, page, args) {
 	}));
 }
 
-var service = webserver.listen('127.0.0.1:0', function (req, res) {
+var service = webserver.listen('127.0.0.1:' + (webserverPort || 0), function (req, res) {
 	// console.log("Got a request of type: " + req.method);
 	if (req.method === 'GET') {
 		res.statusCode = 200;

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -73,6 +73,10 @@ exports.create = function (callback, options) {
         }
         args = args.concat([__dirname + '/bridge.js']);
 
+        if (options.webserverPort) {
+            args.push(options.webserverPort);
+        }
+        
         var phantom = spawn(options.phantomPath, args);
 
         // Ensure that the child process is closed when this process dies
@@ -125,6 +129,10 @@ exports.create = function (callback, options) {
             if (!matches) {
                 phantom.kill();
                 return callback("Unexpected output from PhantomJS: " + data);
+            }
+
+            if (options.webserverPort) {
+                return callback(null, phantom, options.webserverPort);
             }
 
             var phantom_pid = parseInt(matches[1], 0);


### PR DESCRIPTION
Lack of netstat/lsof limited our use case (though lsof would have still required a PR), I'd like to propose this work around until the phantom issue is fixed, I am going to dive into that.