### PR TITLE
PhantomPath on spawn

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -67,13 +67,13 @@ exports.create = function (callback, options) {
     if (options.parameters === undefined) options.parameters = {};
 
     function spawnPhantom (callback) {
-        var args=[];
+        var args=options.phantomPath.split(' ');
         for(var parm in options.parameters) {
             args.push('--' + parm + '=' + options.parameters[parm]);
         }
         args = args.concat([__dirname + '/bridge.js']);
 
-        var phantom = spawn(options.phantomPath, args);
+        var phantom = spawn(args[0], args.slice(1));
 
         // Ensure that the child process is closed when this process dies
         var closeChild = function () {


### PR DESCRIPTION
I made phantomPath more malleable. Now phantomjs can be spawned as "setuid root2 phantomjs" or any other use case.