### PR TITLE
Added SlimerJS support

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -186,4 +186,4 @@ var global_methods = {
 	},
 }
 
-console.log("Ready [" + system.pid + "]");
+console.log("Ready [" + system.pid + "] [" + webserver.port + "]");


### PR DESCRIPTION
Minimal changes for SlimerJS transparent support.

Now you can use both `require('phantomjs').path` and `require('slimerjs').path` for binary location. Already tested in [navit](https://github.com/nodeca/navit).