### PR TITLE
account for alternate ss -nlp output syntax on linux

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -177,7 +177,7 @@ exports.create = function (options, callback) {
                 case 'linux':
                             // Modern distros usually have `iproute2` instead of `net-tools`.
                             // Try `ss` first, then fallback to `netstat`.
-                            cmd = 'if which ss > /dev/null; then ss -nlp | grep ",%d,"; else netstat -nlp | grep "[[:space:]]%d/"; fi';
+                            cmd = 'if which ss > /dev/null; then ss -nlp | grep "[,=]%d,"; else netstat -nlp | grep "[[:space:]]%d/"; fi';
                             break;
                 case 'darwin':
                             cmd = 'lsof -np %d | grep LISTEN';


### PR DESCRIPTION
Hi,

I'm running ubuntu 15.04. node-phantom-simple fails to parse out phantomjs entry from `ss -nlp` output due to bad grep pattern.

On my machine `ss -nlp` produces output:
```
tcp    LISTEN     0      20                                                                              127.0.0.1:58225                                                                                  *:*      users:(("phantomjs",pid=10175,fd=9))
```
And so `grep ",%d,"` failes to match it due to `=` preceeding the pid.

Updated the grep cmd to allow either `,` or `=`