### PR TITLE
Remove process.on([ 'SIGINT', 'SIGTERM' ])

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -21,13 +21,6 @@ var processProxy    = new Emitter();
 
 processProxy.setMaxListeners(0);
 
-[ 'SIGINT', 'SIGTERM' ].forEach(function(sig) {
-  process.on(sig, function () {
-    processProxy.emit(sig);
-  });
-});
-
-
 var queue = function (worker) {
   var _q = [];
   var running = false;


### PR DESCRIPTION
Let the developer close the phantomjs instance via browser.close (defined in setup_new_page function) (issue #81)