### PR TITLE
Support Headers and Footers using page.set('paperSize',paperSize) and phantom.callback

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -10,26 +10,25 @@ var page_id = 1;
 var callback_stack = [];
 var hooks = {
   'paperSize':{
-    preprocessor:function(key,value){
+    set:function(key, value) {
 
       try {
-        if(value && value.header && value.header.contents){
-          value.header.contents = eval('('+value.header.contents+')');
+        if (value && value.header && value.header.contents) {
+          value.header.contents = eval('(' + value.header.contents + ')');
         }
-        if(value && value.footer && value.footer.contents){
-          value.footer.contents = eval('('+value.footer.contents+')');
+        if (value && value.footer && value.footer.contents) {
+          value.footer.contents = eval('(' + value.footer.contents + ')');
         }
         return value;
-      }
-      catch(err){
+      } catch(err) {
         return value;
       }
     },
-    postprocessor:function(key,value) {
+    get:function(key, value) {
       return value;
     }
   }
-}
+};
 
 
 phantom.onError = function (msg, trace) {
@@ -62,17 +61,17 @@ function lookup(obj, key, value) {
   if (arguments.length > 2) {
     if (key.length === 1) {
       try {
-        if (hooks[key] && hooks[key].preprocessor) {
-          value = hooks[key].preprocessor(key, value);
+        if (hooks[key] && hooks[key].set) {
+          value = hooks[key].set(key, value);
         }
         obj[key[0]] = value;
 
-        if (hooks[key] && hooks[key].postprocessor) {
-          return hooks[key].postprocessor(key, obj[key[0]])
+        var retVal1 = obj[key[0]];
+        if (hooks[key] && hooks[key].get) {
+          retVal1 = hooks[key].get(key, retVal1);
         }
-        return obj[key[0]];
-      }
-      catch(err){
+        return retVal1;
+      } catch(err) {
         obj[key[0]] = value;
         return obj[key[0]];
 
@@ -82,7 +81,15 @@ function lookup(obj, key, value) {
   }
 
   if (key.length === 1) {
-    return obj[key[0]];
+    var retVal2 = obj[key[0]];
+    try {
+      if (hooks[key] && hooks[key].get) {
+        retVal2 = hooks[key].get(key, retVal2);
+      }
+    } catch(err) {
+      // ignore
+    }
+    return retVal2;
   }
   return lookup(obj[key[0]], key.slice(1));
 }

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -509,6 +509,10 @@ exports.create = function (options, callback) {
         request_queue.push([ [ 0, 'createPage' ], callbackOrDummy(callback, poll_func) ]);
       },
 
+      callback:function(fn){
+        return 'phantom.callback('+fn.toString()+')';
+      },
+
       injectJs: function (filename, callback) {
         request_queue.push([ [ 0, 'injectJs', filename ], callbackOrDummy(callback, poll_func) ]);
       },

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -509,8 +509,8 @@ exports.create = function (options, callback) {
         request_queue.push([ [ 0, 'createPage' ], callbackOrDummy(callback, poll_func) ]);
       },
 
-      callback:function(fn){
-        return 'phantom.callback('+fn.toString()+')';
+      callback: function (fn) {
+        return 'phantom.callback(' + fn.toString() + ')';
       },
 
       injectJs: function (filename, callback) {
@@ -597,7 +597,7 @@ function setup_long_poll (phantom, port, pages, setup_new_page) {
           console.warn('Error parsing JSON from phantom: ' + err);
           console.warn('Data from phantom was: ' + data);
           cb(new HeadlessError('Error parsing JSON from phantom: ' + err
-            + '\nData from phantom was: ' + data));
+              + '\nData from phantom was: ' + data));
           return;
         }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,11 +8,18 @@ var fs   = require('fs');
 // Generate path in os tmp dir
 function tmp() {
   return path.join(
-    require('os').tmpdir(),
-    require('crypto').randomBytes(8).toString('hex') + '.png'
+      require('os').tmpdir(),
+      require('crypto').randomBytes(8).toString('hex') + '.png'
   );
 }
 
+// Generate path in os tmp dir
+function pdf() {
+  return path.join(
+      require('os').tmpdir(),
+      require('crypto').randomBytes(8).toString('hex') + '.pdf'
+  );
+}
 
 // Copy file to tmp dir & return new name
 function toTmp(filePath) {
@@ -33,5 +40,6 @@ function unlink(filePath) {
 
 
 exports.tmp     = tmp;
+exports.pdf     = pdf;
 exports.toTmp   = toTmp;
 exports.unlink  = unlink;

--- a/test/test_page_render.js
+++ b/test/test_page_render.js
@@ -11,7 +11,7 @@ var driver  = require('../');
 describe('page', function () {
   var server;
   var testFileName = helpers.tmp();
-
+  var testPDF = helpers.pdf();
 
   before(function (done) {
     server = http.createServer(function (request, response) {
@@ -23,61 +23,145 @@ describe('page', function () {
 
   it('render to binary & base64', function (done) {
     driver.create(
-      { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
-      function (err, browser) {
-        if (err) {
-          done(err);
-          return;
-        }
-
-        browser.createPage(function (err, page) {
+        { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
+        function (err, browser) {
           if (err) {
             done(err);
             return;
           }
 
-          page.open('http://localhost:' + server.address().port, function (err, status) {
+          browser.createPage(function (err, page) {
             if (err) {
               done(err);
               return;
             }
 
-            assert.equal(status, 'success');
-
-            page.render(testFileName, function (err) {
+            page.open('http://localhost:' + server.address().port, function (err, status) {
               if (err) {
                 done(err);
                 return;
               }
 
-              var stat = fs.statSync(testFileName);
+              assert.equal(status, 'success');
 
-              // Relaxed check to work in any browser/OS
-              // We should have image and this image should be > 0 bytes.
-              assert.ok(stat.size > 100, 'generated image too small');
-
-
-              page.renderBase64('png', function (err, imagedata) {
+              page.render(testFileName, function (err) {
                 if (err) {
                   done(err);
                   return;
                 }
 
-                // Base64 decoded image should be the same (check size only)
-                assert.equal((new Buffer(imagedata, 'base64')).length, stat.size);
+                var stat = fs.statSync(testFileName);
 
-                browser.exit(done);
+                // Relaxed check to work in any browser/OS
+                // We should have image and this image should be > 0 bytes.
+                assert.ok(stat.size > 100, 'generated image too small');
+
+
+                page.renderBase64('png', function (err, imagedata) {
+                  if (err) {
+                    done(err);
+                    return;
+                  }
+
+                  // Base64 decoded image should be the same (check size only)
+                  assert.equal((new Buffer(imagedata, 'base64')).length, stat.size);
+
+                  browser.exit(done);
+                });
               });
             });
           });
-        });
-      }
+        }
     );
   });
 
+  it('render to pdf with header and foot', function (done) {
+    driver.create(
+        { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
+        function (err, browser) {
+          var phantom = browser;
+          if (err) {
+            done(err);
+            return;
+          }
+
+          browser.createPage(function (err, page) {
+            if (err) {
+              done(err);
+              return;
+            }
+
+            page.open('http://localhost:' + server.address().port, function (err, status) {
+              if (err) {
+                done(err);
+                return;
+              }
+
+              assert.equal(status, 'success');
+
+              page.render(testPDF, function (err) {
+                if (err) {
+                  done(err);
+                  return;
+                }
+
+                var statWithoutHeaderFooter = fs.statSync(testPDF);
+
+                // Relaxed check to work in any browser/OS
+                // We should have image and this image should be > 0 bytes.
+                assert.ok(statWithoutHeaderFooter.size > 1000, 'generated pdf too small');
+
+
+                var paperSize = {
+                  format: 'A4',
+                  margin: '1cm',
+                  header: {
+                    height: '2cm',
+                    contents: phantom.callback(function(pageNum, numPages) {
+                      return '<h1>Header ' + pageNum + ' / ' + numPages + '</h1>';
+                    })
+                  },
+                  footer: {
+                    height: '2cm',
+                    contents: phantom.callback(function(pageNum, numPages) {
+                      return '<h1>Footer ' + pageNum + ' / ' + numPages + '</h1>';
+                    })
+                  }
+                };
+
+                page.set('paperSize', paperSize, function() {
+                  page.render(testPDF, {
+                    format: 'pdf',
+                    quality: '100'
+                  }, function (err) {
+                    if (err) {
+                      done(err);
+                      return;
+                    }
+
+                    var statWithHeaderFooter = fs.statSync(testPDF);
+
+
+                    // Relaxed check to work in any browser/OS
+                    // We should have image and this image should be > 0 bytes.
+                    assert.ok(statWithHeaderFooter.size > 2000, 'generated pdf (header/footer) too small');
+
+                    assert.ok(statWithHeaderFooter.size > statWithoutHeaderFooter.size, 'generated pdf with header & footer can not be smaller than generated pdf without header & footer');
+                    browser.exit(done);
+                  });
+
+                });
+
+              });
+            });
+          });
+        }
+    );
+  });
 
   after(function (done) {
     helpers.unlink(testFileName);
+    helpers.unlink(testPDF);
     server.close(done);
   });
 });

--- a/test/test_page_render.js
+++ b/test/test_page_render.js
@@ -23,7 +23,7 @@ describe('page', function () {
 
   it('render to binary & base64', function (done) {
     driver.create(
-        { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
+      { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
         function (err, browser) {
           if (err) {
             done(err);

--- a/test/test_page_render.js
+++ b/test/test_page_render.js
@@ -23,55 +23,55 @@ describe('page', function () {
 
   it('render to binary & base64', function (done) {
     driver.create(
-      { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
-      function (err, browser) {
-        if (err) {
-          done(err);
-          return;
-        }
-
-        browser.createPage(function (err, page) {
+        { ignoreErrorPattern: /CoreText performance note/, path: require(process.env.ENGINE || 'phantomjs').path },
+        function (err, browser) {
           if (err) {
             done(err);
             return;
           }
 
-          page.open('http://localhost:' + server.address().port, function (err, status) {
+          browser.createPage(function (err, page) {
             if (err) {
               done(err);
               return;
             }
 
-            assert.equal(status, 'success');
-
-            page.render(testFileName, function (err) {
+            page.open('http://localhost:' + server.address().port, function (err, status) {
               if (err) {
                 done(err);
                 return;
               }
 
-              var stat = fs.statSync(testFileName);
+              assert.equal(status, 'success');
 
-              // Relaxed check to work in any browser/OS
-              // We should have image and this image should be > 0 bytes.
-              assert.ok(stat.size > 100, 'generated image too small');
-
-
-              page.renderBase64('png', function (err, imagedata) {
+              page.render(testFileName, function (err) {
                 if (err) {
                   done(err);
                   return;
                 }
 
-                // Base64 decoded image should be the same (check size only)
-                assert.equal((new Buffer(imagedata, 'base64')).length, stat.size);
+                var stat = fs.statSync(testFileName);
 
-                browser.exit(done);
+                // Relaxed check to work in any browser/OS
+                // We should have image and this image should be > 0 bytes.
+                assert.ok(stat.size > 100, 'generated image too small');
+
+
+                page.renderBase64('png', function (err, imagedata) {
+                  if (err) {
+                    done(err);
+                    return;
+                  }
+
+                  // Base64 decoded image should be the same (check size only)
+                  assert.equal((new Buffer(imagedata, 'base64')).length, stat.size);
+
+                  browser.exit(done);
+                });
               });
             });
           });
-        });
-      }
+        }
     );
   });
 


### PR DESCRIPTION
This is a fix for the existing issue - #78

This fix allows us to support the following code snippet

var driver = require('node-phantom-simple');

var phantom = null;


var path = 'out.pdf';

driver.create(function(err, browser) {

    phantom = browser;
    return browser.createPage(function(err, page) {
        return page.open("http://www.google.com/search?q=rohit%20ghatol", function(err, status) {

            var paperSize = {
                format: 'A4',
                margin: "1cm",
                header: {
                    height: "2cm",
                    contents: phantom.callback(function(pageNum, numPages) {
                        return "<h1>Header " + pageNum + " / " + numPages + "</h1>";
                    })
                },
                footer: {
                    height: "2cm",
                    contents: phantom.callback(function(pageNum, numPages) {
                        return "<h1>Footer " + pageNum + " / " + numPages + "</h1>";
                    })
                }
            };
            page.set('paperSize', paperSize, function() {
                page.render(path, {
                    format: 'pdf',
                    quality: '100'
                }, function() {
                  browser.exit();
                    console.log('done');
                });
            });
        });
    });
});
The basic issue here is, node-phantom-simple is extremely good at passing json objects to the actual phantomjs (via bridge). However when we need a functionality like the phantom.callback() function to add headers and footers, there is no way the existing bridge can support it, as it is restricted to json object, functions are ofcourse stripped out.

The solution to this was we added phantom.callback() function in the node-phantom-simple.js, which actually converts the function into string and passes that to the bridge.js

In the bridge.js, I have created a hooks[] array which holds any set or get hooks for any property we set using page.set('pageSize',object). There is a hook particularly for 'pageSize' which looks for pageSize.header.contents and pageSize.footer.contents and converts the string passed to an actual function.

This way we are able to use phantom.callback() abstracting how we pass the callback function to the server. Only catch here is the function will not support any closure variables. We will need to document the fact, since the function runs remotely in the content of phantom.

I have updated the test case test/test_page_render.js, adhered with the lint conventions and was able to run tests (till mine).

Ripple effects of this fix should be minimal.