### PR TITLE
Cleanup lifecycle detection

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -233,8 +233,6 @@ var global_methods = {
 // If this function is called, that means the master process is gone
 // and we should commit suicide
 function onMasterGoneAway () {
-  console.error('node-phantom-simple:worker' + system.pid, 'Master process seems to be gone. Suiciding.');
-
   phantom.exit(2);
 }
 

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -16,7 +16,7 @@ var POLL_INTERVAL   = process.env.POLL_INTERVAL || 500;
 var runningBrowsers = [];
 
 process.on('beforeExit', function () {
-  if (!runningBrowsers.length) { return };
+  if (!runningBrowsers.length) { return; }
 
   console.warn('node-phantom-simple: Killing browser processes still running');
 
@@ -27,7 +27,7 @@ process.on('beforeExit', function () {
 });
 
 process.on('exit', function () {
-  if (!runningBrowsers.length) { return };
+  if (!runningBrowsers.length) { return; }
 
   console.warn('node-phantom-simple: Main process exited whith browser(s) still running.');
 });

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -10,14 +10,13 @@ var spawn           = require('child_process').spawn;
 var exec            = require('child_process').exec;
 var util            = require('util');
 var path            = require('path');
-var Emitter         = require('events').EventEmitter;
 
 var POLL_INTERVAL   = process.env.POLL_INTERVAL || 500;
 
 var runningBrowsers = [];
 
 process.on('beforeExit', function () {
-  if (!runningBrowsers.length) return;
+  if (!runningBrowsers.length) { return };
 
   console.warn('node-phantom-simple: Killing browser processes still running');
 
@@ -28,7 +27,7 @@ process.on('beforeExit', function () {
 });
 
 process.on('exit', function () {
-  if (!runningBrowsers.length) return;
+  if (!runningBrowsers.length) { return };
 
   console.warn('node-phantom-simple: Main process exited whith browser(s) still running.');
 });


### PR DESCRIPTION
Avoid strong assumptions on the user's workflow without sacrificing process
cleanup on exit nor disrupting the host module (see issue #81 for discussion)

  * Remove reliance on SIGINT/SIGTERM process handlers to detect exit as this
    might break commonly used Ctrl+C interruptions;
  * Rely on the `beforeExit` event to kill browser child processes still alive
    when we can (as per the doc, `beforeExit` may not be called in certain
    circumstances);
  * Implement a timeout mechanism on the bridge so that it commits suicide if
    the parent process is gone. This handles the cases where the `beforeExit`
    handler is not called, such as a direct `process.exit()` call or the parent
    process being SIGKILLed;
  * Assume the parent is alive everytime it sends a request to the HTTP
    communication endpoint;
  * For now, we rely on the longpoll mechanism that sends a packet every 500ms;
  * The bridge also accepts HEAD requests that are basically ignored (replies
    with HTTP 200 and no content) and can be used as PINGs should the
    piggybacking of longpoll prove not to be sufficient/robust enough;
  * Warn the user when the parent process terminates with browsers still running
    to promote best practice.