### PR TITLE
Error on connection drops

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -645,6 +645,12 @@ function setup_long_poll (phantom, port, pages, setup_new_page) {
     req.on('error', function (err) {
       if (dead || phantom.killed) { return; }
 
+      if (err.code === 'ECONNRESET') {
+        dead = true;
+        cb(new HeadlessError('Phantom Process died'));
+        return;
+      }
+
       logger.warn('Poll Request error: ' + err);
     });
   };

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -645,7 +645,12 @@ function setup_long_poll (phantom, port, pages, setup_new_page) {
     req.on('error', function (err) {
       if (dead || phantom.killed) { return; }
 
-      if (err.code === 'ECONNRESET') {
+      if (err.code === 'ECONNRESET' || err.code === 'ECONNREFUSED') {
+        try {
+          phantom.kill();
+        } catch (e) {
+          // we don't care
+        }
         dead = true;
         cb(new HeadlessError('Phantom Process died'));
         return;


### PR DESCRIPTION
In some cases a
```
node-phantom-simple:warn Poll Request error: Error: read ECONNRESET
```
or a
```
node-phantom-simple:warn Poll Request error: Error: connect ECONNREFUSED 127.0.0.1:60482
```
can happen. In those cases `node-phantom-simple` still behaves as if the PhantomJS instance is in a normal state, which makes the execution hang, as the callback is not fired.