### PR TITLE
fix: parse 127.0.0.0/8 properly

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -240,7 +240,7 @@ exports.create = function (options, callback) {
           stdout = '';
         }
 
-        var re = /(?:127\.0\.0\.1|localhost):(\d+)/ig, match;
+        var re = /(?:127\.\d{1,3}\.\d{1,3}\.\d{1,3}|localhost):(\d+)/ig, match;
         var ports = [];
 
         while ((match = re.exec(stdout)) !== null) {


### PR DESCRIPTION
In FreeBSD jail localhost can be != 127.0.0.1 and still be loopback
interface. This patch expands the regex that matches the loopback
address, which in turn fixes running tasks on FreeBSD.