### PR TITLE
add memory leak test

### DIFF
--- a/test/test_memory_leak.js
+++ b/test/test_memory_leak.js
@@ -1,0 +1,64 @@
+'use strict';
+
+
+var assert = require('assert');
+var driver = require('../');
+
+describe('memory leak', function() {
+  it('create 10 browsers', function(done) {
+
+    this.timeout(60 * 60 * 1000);
+
+    var limit = 100;
+    var count = 0;
+
+    var memoryUsageStart = process.memoryUsage();
+    var memoryUsageLast = memoryUsageStart;
+
+    create();
+
+    function exit() {
+      count++;
+      console.log('browser count:', count);
+      var memoryUsage = calculateMemoryUsage();
+      if (count < limit) {
+        create();
+      } else {
+        done();
+      }
+      memoryUsageLast = memoryUsage;
+    }
+
+    function calculateMemoryUsage(memoryUsage) {
+      var memoryUsage = process.memoryUsage();
+      log('rss', memoryUsage, memoryUsageLast, memoryUsageStart);
+      log('heapTotal', memoryUsage, memoryUsageLast, memoryUsageStart);
+      log('heapUsed', memoryUsage, memoryUsageLast, memoryUsageStart);
+      return memoryUsage;
+    }
+
+    function create() {
+      driver.create({ path: require(process.env.ENGINE || 'phantomjs-prebuilt').path }, function(err, browser) {
+        if (err) {
+          done(err);
+          return;
+        }
+        browser.exit(exit);
+      });
+    }
+
+  });
+
+});
+
+function percentIncrease(before, after) {
+  return (((after - before) / before) * 100).toFixed(0);
+}
+
+function log(propName, current, last, start) {
+  console.log('%s increase: %d% (%d% total)',
+    propName,
+    percentIncrease(last[propName], current[propName]),
+    percentIncrease(start[propName], current[propName])
+  );
+}


### PR DESCRIPTION
memory leak test for #117 

It creates a new browser instance, exits, then creates another and then repeats the whole process. It doesn't yet actually test it, just display the logs. I'm not sure how much increase should be considered to pass/fail the test. But by the 24th iteration the `heapUsed` increase is up by 50%

    browser count: 24
    rss increase: 0% (19% total)
    heapTotal increase: 0% (41% total)
    heapUsed increase: 1% (53% total)