### PR TITLE
Fixes page.getPage to return a page object

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -74,6 +74,33 @@ function page_open (res, page, args) {
   }));
 }
 
+function page_get_page(res, page, args) {
+  var new_page;
+  var error;
+  var id = null;
+
+  try {
+    new_page = page.getPage.apply(page, args);
+  } catch (err) {
+    error = err;
+  }
+
+  if (new_page) {
+    id = setup_page(new_page);
+  }
+
+  res.setHeader('Content-Type', 'application/json');
+  if (error) {
+    res.statusCode = 500;
+    res.write(JSON.stringify(error));
+  } else {
+    res.statusCode = 200;
+    res.write(JSON.stringify({ data: id }));
+  }
+
+  res.close();
+}
+
 function include_js (res, page, args) {
   res.statusCode = 200;
   res.setHeader('Content-Type', 'application/json');
@@ -116,6 +143,8 @@ webserver.listen('127.0.0.1:0', function (req, res) {
           return page_open(res, pages[request.page], request.args);
         } else if (request.method === 'includeJs') {
           return include_js(res, pages[request.page], request.args);
+        } else if (request.method === 'getPage') { // special case due to retrieving page
+          return page_get_page(res, pages[request.page], request.args);
         }
         try {
           output = pages[request.page][request.method].apply(pages[request.page], request.args);

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -288,7 +288,7 @@ exports.create = function (options, callback) {
       var methods = [
         'addCookie', 'childFramesCount', 'childFramesName', 'clearCookies', 'close',
         'currentFrameName', 'deleteCookie', 'evaluateJavaScript',
-        'evaluateAsync', 'getPage', 'go', 'goBack', 'goForward', 'includeJs',
+        'evaluateAsync', 'go', 'goBack', 'goForward', 'includeJs',
         'injectJs', 'open', 'openUrl', 'release', 'reload', 'render', 'renderBase64',
         'sendEvent', 'setContent', 'stop', 'switchToFocusedFrame', 'switchToFrame',
         'switchToFrame', 'switchToChildFrame', 'switchToChildFrame', 'switchToMainFrame',
@@ -346,6 +346,31 @@ exports.create = function (options, callback) {
           }
 
           request_queue.push([ [ id, 'evaluate', fn.toString() ].concat(extra_args), callbackOrDummy(cb, poll_func) ]);
+        },
+
+        getPage: function(name, cb) {
+          if (typeof cb !== 'function') {
+            cb = function() {};
+          }
+
+          // Create a wrapper function that setups
+          // new page if phantom finds a page,
+          // otherwise send null
+          var wrapperFn = function(err, page_id) {
+            if (err) {
+              return cb(err, null);
+            }
+
+            if (!page_id && page_id !== 0) {
+              return cb(null, null);
+            }
+
+            var new_page = setup_new_page(page_id);
+
+            cb(null, new_page);
+          };
+
+          request_queue.push([ [ id, 'getPage', name ], callbackOrDummy(wrapperFn, poll_func) ]);
         },
 
         waitForSelector: function (selector, timeout, cb) {

--- a/test/test_page_get_page.js
+++ b/test/test_page_get_page.js
@@ -1,0 +1,97 @@
+'use strict';
+
+
+var assert  = require('assert');
+var driver  = require('../');
+
+describe('page.getPage()', function() {
+
+  it('should retrieve pages as actual node-phantom-simple pages (#131)', function(done) {
+    var path = require(process.env.ENGINE || 'phantomjs').path;
+    driver.create({ path: path }, function(err, browser) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      browser.createPage(function(err, page) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        var child_page_name = 'child_page';
+        // this should be called when
+        // window.open is executed
+        page.onPageCreated = function(childPage) {
+          // Set the name of the child so it can be retrieved
+          childPage.evaluate(function(name_to_use) {
+            window.name = name_to_use;
+            window.special_recognisable_property = 5;
+          }, child_page_name, function() {
+            // Retrieve the previous childPage, now through getPage
+            page.getPage(child_page_name, function(err, new_child_page) {
+              if (err) {
+                done(err);
+                return;
+              }
+
+              assert.strictEqual(typeof new_child_page, 'object');
+              assert.strictEqual(typeof new_child_page.evaluate, 'function');
+              new_child_page.evaluate(function() {
+                // tried using window.name, but slimerjs returns empty string,
+                // but still matches the correct page
+                return window.special_recognisable_property;
+              }, function(err, special_prop) {
+                if (err) {
+                  done(err);
+                  return;
+                }
+
+                assert.strictEqual(special_prop, 5);
+                browser.exit(done);
+              });
+            });
+          });
+        };
+
+        // open an empty new page
+        page.evaluate(function() {
+          window.open('');
+        }, function(err) {
+          if (err) {
+            done(err);
+            return;
+          }
+        });
+      });
+    });
+  });
+
+  it('should return null when page with given name cannot be found', function(done) {
+    var path = require(process.env.ENGINE || 'phantomjs').path;
+    driver.create({ path: path }, function(err, browser) {
+      if (err) {
+        done(err);
+        return;
+      }
+
+      browser.createPage(function(err, page) {
+        if (err) {
+          done(err);
+          return;
+        }
+
+        page.getPage('some-name', function(err, child_page) {
+          if (err) {
+            done(err);
+            return;
+          }
+
+          assert.strictEqual(child_page, null);
+          browser.exit(done);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Prior to this fix, the page object that would be returned would be missing functions and have properties that are unique to the PhantomJS page object. This fixes issue #131.

The function will, as it is suppose to, return a page object if it finds an object with the given name or it'll return null.

It needed its own special function as it needs to setup a new page, both in bridge.js and node-phantom-simple.js. Also added test to make sure it works correctly.