### PR TITLE
Allow bridge host and port to be specified via options

### DIFF
--- a/bridge.js
+++ b/bridge.js
@@ -3,6 +3,8 @@
 var webpage     = require('webpage');
 var webserver   = require('webserver').create();
 var system      = require('system');
+var host        = system.args[1];
+var port        = system.args[2];
 
 var pages  = {};
 var page_id = 1;
@@ -91,7 +93,7 @@ function include_js (res, page, args) {
   }));
 }
 
-webserver.listen('127.0.0.1:0', function (req, res) {
+webserver.listen(host + ':' + port, function (req, res) {
   // Update watchdog timer on every request
   watchdog_clear();
 

--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -124,6 +124,7 @@ exports.create = function (options, callback) {
   if (typeof options.parameters === 'undefined') { options.parameters = {}; }
 
   function spawnPhantom (callback) {
+    var bridgeDefaults = { host: '127.0.0.1', port: '0' };
     var args = [];
 
     if (Array.isArray(options.parameters)) {
@@ -135,6 +136,9 @@ exports.create = function (options, callback) {
     }
 
     args = args.concat([ path.join(__dirname, 'bridge.js') ]);
+
+    var bridgeOptions = Object.assign(bridgeDefaults, options.bridge || {});
+    args = args.concat([ bridgeOptions.host, bridgeOptions.port ]);
 
     var phantom = spawn(options.path, args);
 


### PR DESCRIPTION
I recently ran in to an issue in Docker (like several other people have, based on what I've seen) where `netstat` and `ss` don't actually return the port used, and `node-phantom-simple` falls apart. We found that privileged containers worked fine, but we needed to run unprivileged containers.

Of course there have been [several](https://github.com/baudehlo/node-phantom-simple/issues/9) [issues](https://github.com/baudehlo/node-phantom-simple/issues/76) [here](https://github.com/baudehlo/node-phantom-simple/issues/104) [related](https://github.com/baudehlo/node-phantom-simple/issues/125) to netstat/ss for port detection based on pid. 

Long story short, the problem doesn't actually seem to be with Phantom, but instead with the bridge. 

We discovered that this library was binding the bridge server to port 0, and that there was [already code to handle the port not being 0](https://github.com/baudehlo/node-phantom-simple/blob/master/node-phantom-simple.js#L179-L182). So I tried passing the port into the bridge using the argument passthrough in the [phantom cli](http://phantomjs.org/api/command-line.html) and everything worked as expected in our unprivileged containers.

This doesn't change the default operation of `node-phantom-simple`, it simply allows users to pass in the `bridge.host` and `bridge.post` as options in `driver.create()`.

I don't know if this will solve all of the port problems for others as well, and I'll admit that I only tested this with Phantom 1.9.8, but I haven't run in to any issues specifying my own port yet. I included the host, but I'm not sure there's a need to, the port was all that seemed important here. I would also be open to flattening the options to something like `bridgeHost` and `bridgePost`, or whatever you'd prefer. 

This seems really useful in upstream here, and I'm happy to update this PR as you see fit.