### PR TITLE
change the way to use spawn

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -136,7 +136,29 @@ exports.create = function (options, callback) {
 
     args = args.concat([ path.join(__dirname, 'bridge.js') ]);
 
-    var phantom = spawn(options.path, args);
+    var phantom;
+    // if platform is win32 and the path contains space, using some hacks for the spawn method
+  	if (process.platform == 'win32' && options.path.indexOf(' ') >= 0) {
+  		var args = [
+  			"/S",
+  			"/C",
+  			'"',
+  			options.path,
+  		].concat('bridge.js').concat('"');
+  
+  		var command = process.env.comspec || "cmd.exe";
+  
+  		phantom = spawn(
+  			command,
+  			args,
+  			{
+  				windowsVerbatimArguments: true,
+  				cwd: __dirname
+  			}
+  		);
+  	} else {
+  		phantom = spawn(options.path, args);
+  	}
 
     phantom.once('error', function (err) {
       callback(err);


### PR DESCRIPTION
If the platform is win32 and path contains space, spawn will not execute correctly.
For example, if the path of slimerjs is **C:\Program Files\slimerjs\sliemrjs.bat**. The spawn will treat **C:\Program** as the command and **Files\slimerjs\sliemrjs.bat...** as args. The way to solve it is to use **\S** and **\C** args of the cmd, which is methioned by @progmars of the following post.

Relate Post: https://github.com/nodejs/node-v0.x-archive/issues/25895

Relate Issue: https://github.com/baudehlo/node-phantom-simple/issues/140