### PR TITLE
Allow PhantomJS ready message without port

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -162,7 +162,7 @@ exports.create = function (options, callback) {
         logger.debug('' + data);
       });
 
-      var matches = data.toString().match(/Ready \[(\d+)\] \[(.+?)\]/);
+      var matches = data.toString().match(/Ready \[(\d+)\] \[(.*?)\]/);
 
       if (!matches) {
         phantom.kill();
@@ -172,7 +172,7 @@ exports.create = function (options, callback) {
 
       phantom.removeListener('exit', immediateExit);
 
-      var phantom_port = matches[2].indexOf(':') === -1 ? matches[2] : matches[2].split(':')[1];
+      var phantom_port = !matches[2] || matches[2].indexOf(':') === -1 ? (matches[2] || '0') : matches[2].split(':')[1];
 
       phantom_port = parseInt(phantom_port, 0);
 


### PR DESCRIPTION
Fixes #125

Sometimes PhantomJS will report no port number using `[]`, which trips up the RegExp that expects 1 or more characters between the brackets.