### PR TITLE
Fix onLoadFinished sometimes being called with wrong arguments

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -65,10 +65,6 @@ function callbackOrDummy(callback, poll_func) {
   return callback;
 }
 
-function unwrapArray(arr) {
-  return arr && arr.length === 1 ? arr[0] : arr;
-}
-
 function wrapArray(arr) {
   // Ensure that arr is an Array
   return (arr instanceof Array) ? arr : [ arr ];
@@ -628,13 +624,7 @@ function setup_long_poll(phantom, port, pages, setup_new_page) {
             } else if (pages[r.page_id] && pages[r.page_id][r.callback]) {
               callbackFunc = pages[r.page_id][r.callback];
 
-              if (callbackFunc.length > 1) {
-                // We use `apply` if the function is expecting multiple args
-                callbackFunc.apply(pages[r.page_id], wrapArray(r.args));
-              } else {
-                // Old `call` behaviour is deprecated
-                callbackFunc.call(pages[r.page_id], unwrapArray(r.args));
-              }
+              callbackFunc.apply(pages[r.page_id], wrapArray(r.args));
             }
           } else {
             cb = callbackOrDummy(phantom[r.callback]);

--- a/test/test_page_push_notifications.js
+++ b/test/test_page_push_notifications.js
@@ -209,7 +209,7 @@ describe('push notifications', function () {
           return;
         }
 
-        page.onLoadFinished = function (status) {
+        page.onLoadFinished = function () {
           browser.exit(done);
         };
 

--- a/test/test_page_push_notifications.js
+++ b/test/test_page_push_notifications.js
@@ -209,7 +209,7 @@ describe('push notifications', function () {
           return;
         }
 
-        page.onLoadFinished = function () {
+        page.onLoadFinished = function (status) {
           browser.exit(done);
         };
 
@@ -219,7 +219,7 @@ describe('push notifications', function () {
             return;
           }
 
-          assert.equal(status, 'success');
+          assert.strictEqual(status, 'success');
         });
       });
     });


### PR DESCRIPTION
With SlimerJS, `onLoadFinished` was called with an array of the arguments as the first argument, instead of actually receiving multiple arguments. This fixes that.

There was already a test for `onLoadFinished`, but I changed to it fail like it should for the above scenario.
