### PR TITLE
Removing get pid alternative command that not works on gcloud container instance

### DIFF
--- a/node-phantom-simple.js
+++ b/node-phantom-simple.js
@@ -203,7 +203,7 @@ exports.create = function (options, callback) {
           //    between versions.
           // - `ss` can exist but fail in some env (#76).
           //
-          cmd = 'ss -nlp | grep "[,=]%d," || netstat -nlp | grep "[[:space:]]%d/"';
+          cmd = 'netstat -nlp | grep "[[:space:]]%d/"';
           break;
 
         case 'darwin':


### PR DESCRIPTION
The follow code line trigger an error on gcloud container instance throwning:

"Error executing command to extract phantom ports: Error: Command failed: ss -nlp | grep "[,=]39," || netstat -nlp | grep "[[:space:]]39/" /bin/sh: 1: ss: not found /bin/sh: 1: netstat: not found"

This error catch a phantom kill instance. 